### PR TITLE
[FEAT/#1] Implement KIS access token issuance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Secret
+src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: stock-trade-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: stock_trade
+    ports:
+      - "3306:3306"

--- a/src/main/java/com/sandbox/stock_trade/StockTradeApplication.java
+++ b/src/main/java/com/sandbox/stock_trade/StockTradeApplication.java
@@ -2,7 +2,6 @@ package com.sandbox.stock_trade;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
 @SpringBootApplication
 public class StockTradeApplication {
 

--- a/src/main/java/com/sandbox/stock_trade/kis/KisConfig.java
+++ b/src/main/java/com/sandbox/stock_trade/kis/KisConfig.java
@@ -1,0 +1,16 @@
+package com.sandbox.stock_trade.kis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kis")
+public class KisConfig {
+    private String appKey;
+    private String appSecret;
+    private String baseUrl;
+}

--- a/src/main/java/com/sandbox/stock_trade/kis/KisController.java
+++ b/src/main/java/com/sandbox/stock_trade/kis/KisController.java
@@ -1,0 +1,19 @@
+package com.sandbox.stock_trade.kis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kis")
+@RequiredArgsConstructor
+public class KisController {
+
+    private final KisTokenClient kisTokenClient;
+
+    @GetMapping("/token")
+    public String getToken() {
+        return kisTokenClient.fetchAccessToken();
+    }
+}

--- a/src/main/java/com/sandbox/stock_trade/kis/KisTokenClient.java
+++ b/src/main/java/com/sandbox/stock_trade/kis/KisTokenClient.java
@@ -1,0 +1,32 @@
+package com.sandbox.stock_trade.kis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KisTokenClient {
+
+    private final KisConfig kisConfig;
+
+    public String fetchAccessToken() {
+        WebClient client = WebClient.create(kisConfig.getBaseUrl());
+
+        KisTokenResponse response = client.post()
+                .uri("/oauth2/tokenP")
+                .header("Content-Type", "application/json")
+                .bodyValue(Map.of(
+                        "grant_type", "client_credentials",
+                        "appkey", kisConfig.getAppKey(),
+                        "appsecret", kisConfig.getAppSecret()
+                ))
+                .retrieve()
+                .bodyToMono(KisTokenResponse.class)
+                .block();
+
+        return response.getAccessToken();
+    }
+}

--- a/src/main/java/com/sandbox/stock_trade/kis/KisTokenResponse.java
+++ b/src/main/java/com/sandbox/stock_trade/kis/KisTokenResponse.java
@@ -1,0 +1,17 @@
+package com.sandbox.stock_trade.kis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KisTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+kis:
+  app-key: PSn0Re9QYwvcMPij3TIEto5VRxs2HCWmUfaL
+  app-secret: FE72su0/nyxhk4V8Yj+a7xrjbGtoY+nwQUi3pIhhAndIl9syv/4xIZkdoYpbp4W44u64kdPW3kWfSyEaTAzrZQb7HwxNB+5O9fsEeQQYEKdCpN2o5DhSu8G729REzjXzeP7g0B4B1nidEpzXdy7iC1+e1RAxe+56BOqxs+sdsiVaqjXeUbE=
+  base-url: https://openapivts.koreainvestment.com:29443  # 모의투자 URL
+
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/stock_trade
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Stock Trade Sandbox</title>
+    <style>
+        body { font-family: sans-serif; max-width: 600px; margin: 60px auto; }
+        button { padding: 10px 20px; cursor: pointer; background: #4CAF50; color: white; border: none; border-radius: 4px; }
+        #result { margin-top: 20px; padding: 16px; background: #f4f4f4; border-radius: 4px; word-break: break-all; display: none; }
+    </style>
+</head>
+<body>
+<h2>📈 Stock Trade Sandbox</h2>
+
+<button onclick="fetchToken()">Get KIS Access Token</button>
+<div id="result"></div>
+
+<script>
+    async function fetchToken() {
+        const result = document.getElementById('result');
+        result.style.display = 'block';
+        result.innerText = 'Loading...';
+
+        try {
+            const res = await fetch('/kis/token');
+            const token = await res.text();
+            result.innerText = '✅ Token: ' + token;
+        } catch (e) {
+            result.innerText = '❌ Error: ' + e.message;
+        }
+    }
+</script>
+</body>
+</html>

--- a/src/test/java/com/sandbox/stock_trade/KisTokenClientTest.java
+++ b/src/test/java/com/sandbox/stock_trade/KisTokenClientTest.java
@@ -1,0 +1,24 @@
+package com.sandbox.stock_trade;
+
+import com.sandbox.stock_trade.kis.KisTokenClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class KisTokenClientTest {
+
+    @Autowired
+    private KisTokenClient kisTokenClient;
+
+    @Test
+    void fetchAccessToken_success() {
+        String token = kisTokenClient.fetchAccessToken();
+
+        System.out.println("Access Token: " + token);
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 📌 변경 사항
Implement KIS API OAuth2 access token issuance via WebClient.

## ✅ 체크리스트
- [x] Add KIS config properties (app-key, app-secret, base-url)
- [x] Implement token request via WebClient (POST /oauth2/tokenP)
- [x] Map token response to DTO
- [x] Verify token is returned correctly in test

## 📎 참고 자료
- [KIS Developers API Docs](https://apiportal.koreainvestment.com)